### PR TITLE
fix: cgo go pointer to go pointer

### DIFF
--- a/rcl/node_test.go
+++ b/rcl/node_test.go
@@ -12,6 +12,8 @@ func TestNodeCreation(t *testing.T) {
 
 	// Initialization
 	rclCtx := GetZeroInitializatiedContext()
+	defer Shutdown(rclCtx)
+
 	Init(rclCtx)
 	myNode := GetZeroInitializedNode()
 	myNodeOpts := GetNodeDefaultOptions()
@@ -20,5 +22,4 @@ func TestNodeCreation(t *testing.T) {
 	NodeInit(&myNode, "fakeNameForNode", "", rclCtx, myNodeOpts)
 	time.Sleep(10 * time.Second) // or runtime.Gosched() or similar per @misterbee
 	NodeFini(myNode)
-	Shutdown(rclCtx)
 }

--- a/rcl/publisher.go
+++ b/rcl/publisher.go
@@ -54,9 +54,7 @@ func PublisherInit(publisher Publisher,
 		(*C.struct_rcl_node_t)(unsafe.Pointer(node.RCLNode)),
 		(*C.rosidl_message_type_support_t)(unsafe.Pointer(msg.ROSIdlMessageTypeSupport)),
 		(*C.char)(unsafe.Pointer(tName)),
-		// (*C.char)(unsafe.Pointer(tName)),
-		(*C.struct_rcl_publisher_options_t)(unsafe.Pointer(C.NULL)),
-		// (*C.struct_rcl_publisher_options_t)(unsafe.Pointer(pubOpts.RCLPublisherOptions)),
+		(*C.struct_rcl_publisher_options_t)(unsafe.Pointer(pubOpts.RCLPublisherOptions)),
 	))
 
 }


### PR DESCRIPTION
This PR fixes two problems which cause the tests to fail.

## runtime error: cgo argument has go pointer to go pointer

To fix this the context is created in C-memory. (malloc is called).
I don't know if this is the proper way to do it, but it works.

## publisher: options argument is null

I just added some already existing code from a comment.
Was there another issue with this code or why was it a comment?


## About this repo

Since there is no issue tab available I am asking this here.
I am interested in contributing to a rclgo repository. This repo seems to be the most up to date, because it aims to support ros2 foxy and has a recent commit. Let me know if you are interested in contributions. If so it would be nice to add the issue tab, so further disscussions are possible. 